### PR TITLE
Allow cache size to be specified in terms of memory (*bytes)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Depends:
 License: MIT
 LazyData: true
 Imports:
-    R6
+    R6,
+    pryr
 Suggests:
     knitr,
     microbenchmark,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,3 +2,4 @@
 
 export(LRUcache)
 import(R6)
+import(pryr)

--- a/R/cacher-package.R
+++ b/R/cacher-package.R
@@ -1,6 +1,6 @@
 #' In-memory cache interface.
 #'
 #' @name cacher
-#' @import R6
+#' @import pryr R6
 #' @docType package
 NULL

--- a/R/lru.R
+++ b/R/lru.R
@@ -1,8 +1,16 @@
 LRUcache_class <- R6::R6Class("LRUcache",
   public = list(
     initialize = function(size) {
-      stopifnot(all.equal(size, as.integer(size)) && length(size) == 1 && size > 0)
-      private$max_num = size
+      # Parse size
+      if(is.character(size)){
+        # Check that string actually describes a size
+        stopifnot(length(regmatches(size,regexpr('[0-9.]+[kmg]?b?',size, ignore.case=TRUE))) > 0)
+        private$max_num = private$convert_size_to_bytes(size)
+        private$use_bytes = TRUE
+      } else {
+        stopifnot(all.equal(size, as.integer(size)) && length(size) == 1 && size > 0)
+        private$max_num = size
+      }
     },
     exists = function(name) {
       stopifnot(is.character(name) && length(name) == 1)
@@ -10,7 +18,13 @@ LRUcache_class <- R6::R6Class("LRUcache",
     },
     set = function(name, value) {
       stopifnot(is.character(name) && length(name) == 1)
-      if (length(private$data) == private$max_num && !(name %in% ls(private$data))) private$evict()
+      # Check if this value alone exceeds the cache size
+      size <- if(private$use_bytes) as.integer(as.character(pryr::object_size(value))) else 1
+      if (size > private$max_num){
+        stop(sprintf("%s is too big (%d) to fit in the cache (%d).  Consider creating a larger cache.",name, size, private$max_num))
+      }
+      # Check for eviction
+      while (private$get_current_size() + size > private$max_num && !(name %in% ls(private$data))) private$evict()
       private$save(name, value)
       invisible(self)
     },
@@ -28,6 +42,7 @@ LRUcache_class <- R6::R6Class("LRUcache",
   private = list(
     max_num = 0,
     data    = new.env(),
+    use_bytes = FALSE,
     save    = function(name, value) {
       private$data[[name]] <- list(value = value, timestamp = Sys.time())
     },
@@ -44,6 +59,26 @@ LRUcache_class <- R6::R6Class("LRUcache",
       times  <- sapply(private$data, function(elem) elem$timestamp)
       oldest <- names(which.min(times))
       rm(list = oldest, envir = private$data)
+    },
+    convert_size_to_bytes = function(size){ # size is a string, e.g. "100mb"
+      qty <- as.double(regmatches(size, regexpr("[0-9.]+", size))) # e.g. 100, 12.5
+      units <- substring(toupper(regmatches(size, regexpr("[a-z]+", size, ignore.case=TRUE))),1,1) # e.g. "B","K","M", "G"...
+      # Convert size to bytes
+      pow <- switch(units,
+        "B"=0,
+        "K"=1,
+        "M"=2,
+        "G"=3)
+      qty * (1000^pow) # pryr::object_size assumes 1KB = 1000B rather than 1024B
+    },
+    get_current_size = function(){ # in bytes
+      if(length(private$data) == 0){
+        0
+      } else if(private$use_bytes){
+        Reduce(sum, lapply(private$data, function(x) {as.integer(as.character(pryr::object_size(x)))}))
+      } else {
+        length(private$data)
+      }
     }
   )
 )

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -43,7 +43,8 @@ describe('Using LRU cache', {
     # foo should've been bumped due to size
     expect_false(cache$exists('foo'))
 
-    # error should raise with too large object
-    expect_error(cache$set('big',c(1:1e6)))
+    # warning should raise with too large object
+    expect_warning(cache$set('big', c(1:1e6)))
+    expect_false(cache$exists('big'))
   })
 })

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -33,4 +33,17 @@ describe('Using LRU cache', {
     # did not update the timestamp metadata
     expect_true(cache$last_accessed('hello') < cache$last_accessed('cache'))
   })
+
+  test_that('Test with byte size', {
+    cache <- LRUcache('150B')
+    cache$set('foo', 54.124)
+    cache$set('bar', 54.124)
+    cache$set('baz', 54.124)
+
+    # foo should've been bumped due to size
+    expect_false(cache$exists('foo'))
+
+    # error should raise with too large object
+    expect_error(cache$set('big',c(1:1e6)))
+  })
 })


### PR DESCRIPTION
`cacher` parses the argument; if it's a string it should describe a size, e.g. "100 MB" otherwise it should be an integer describing the number of entries the cache can accommodate.

If `cacher` is initialized with a disk space size, it should perform caching with respect to the sizes of objects getting added, not quantity of objects.
