### PR TITLE
Use as.numeric instead of as.integer

### DIFF
--- a/R/lru.R
+++ b/R/lru.R
@@ -8,7 +8,7 @@ LRUcache_class <- R6::R6Class("LRUcache",
         private$max_num = private$convert_size_to_bytes(size)
         private$use_bytes = TRUE
       } else {
-        stopifnot(all.equal(size, as.integer(size)) && length(size) == 1 && size > 0)
+        stopifnot(all.equal(size, as.numeric(size)) && length(size) == 1 && size > 0)
         private$max_num = size
       }
     },
@@ -76,7 +76,7 @@ LRUcache_class <- R6::R6Class("LRUcache",
       if(length(private$data) == 0){
         0
       } else if(private$use_bytes){
-        Reduce(sum, lapply(private$data, function(x) {as.integer(as.character(pryr::object_size(x)))}))
+        Reduce(sum, lapply(private$data, function(x) {as.numeric(as.character(pryr::object_size(x)))}))
       } else {
         length(private$data)
       }

--- a/R/lru.R
+++ b/R/lru.R
@@ -8,7 +8,7 @@ LRUcache_class <- R6::R6Class("LRUcache",
         private$max_num = private$convert_size_to_bytes(size)
         private$use_bytes = TRUE
       } else {
-        stopifnot(all.equal(size, as.numeric(size)) && length(size) == 1 && size > 0)
+        stopifnot(all.equal(size, as.integer(size)) && length(size) == 1 && size > 0)
         private$max_num = size
       }
     },
@@ -38,7 +38,7 @@ LRUcache_class <- R6::R6Class("LRUcache",
     use_bytes = FALSE,
     save    = function(name, value) {
       # Check if this value alone exceeds the cache size
-      size <- if(private$use_bytes) as.integer(as.character(pryr::object_size(value))) else 1
+      size <- if(private$use_bytes) as.numeric(as.character(pryr::object_size(value))) else 1
       if (size > private$max_num){
         warning(sprintf("In package cacher: '%s' is too large (%dB) to fit in the LRU cache (%dB) and will not be cached. Consider creating a larger cache.", name, size, private$max_num), call. = FALSE)
         return(NULL)

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -47,4 +47,16 @@ describe('Using LRU cache', {
     expect_warning(cache$set('big', c(1:1e6)))
     expect_false(cache$exists('big'))
   })
+
+  test_that('Test with large objects', {
+
+    cache <- LRUcache('3GB')
+    testthat::with_mock(
+      `pryr::object_size` = function(...) "2147483648", # .Machine$integer.max + 1
+      cache$set('foo', "some really big object"),
+      expect_true(pryr::object_size("some really big object") == "2147483648"),
+      expect_true(cache$exists('foo'))
+      )
+  })
+
 })


### PR DESCRIPTION
If `s` is a string describing an integer, e.g. `s = "99999"`, `as.integer(s)` would fail to convert it to an integer if it is beyond `.Machine$integer.max` (2147483647).

Use `as.numeric(s)` instead, which supports integers up to `.Machine$double.xmax` or 1.797693e+308.
