### PR TITLE
Public peek

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: cacher
 Type: Package
 Title: cacher (http://github.com/kirillseva/cacher)
 Description: In-memory cache interfaces for R.
-Version: 0.1.0
+Version: 0.1.1
 Author: Kirill Sevastyanenko <kirillseva@gmail.com>
 Maintainer: Kirill Sevastyanenko <kirillseva@gmail.com>
 Authors@R: c(person("Kirill", "Sevastyanenko",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.1.1
+- Added `peek` to perform `get` without updating the timestamp.
+
 # Version 0.0.8
 - Added `forget` to drop the cache for a particular key.
 

--- a/R/lru.R
+++ b/R/lru.R
@@ -28,7 +28,7 @@ LRUcache_ <- R6::R6Class("LRUcache_",
     last_accessed = function(name) {
       stopifnot(is.character(name) && length(name) == 1)
       stopifnot(name %in% ls(private$data))
-      private$peek(name)
+      private$data[[name]]$timestamp
     },
     print = function() {
       cat(sprintf("<LRUcache> of capacity %0.f%s", private$max_num, private$units),
@@ -57,10 +57,6 @@ LRUcache_ <- R6::R6Class("LRUcache_",
     fetch   = function(name) {
       private$data[[name]]$timestamp <- Sys.time()
       private$data[[name]]$value
-    },
-    peek    = function(name) {
-      # Do not update the timestamp on peek
-      private$data[[name]]$timestamp
     },
     evict   = function() {
       # This is very LRU specific. Evict the last used variable

--- a/R/lru.R
+++ b/R/lru.R
@@ -17,6 +17,11 @@ LRUcache_ <- R6::R6Class("LRUcache_",
       stopifnot(name %in% ls(private$data))
       private$fetch(name)
     },
+    peek = function(name) {
+      stopifnot(is.character(name) && length(name) == 1)
+      stopifnot(name %in% ls(private$data))
+      private$data[[name]]$value
+    },
     forget = function(name) {
       stopifnot(is.character(name) && length(name) == 1)
       if (!(name %in% ls(private$data))) {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ cache3$set("key", "this is your value")  # set a value at a particular key...
 cache3$get("key")                        # ...and get that value back!
 [1] "this is your value"
 
+cache3$peek("key")                       # doesn't alter the key's timestamp
+[1] "this is your value"
+
 cache3$exists("key")                     # ...see if your key exists
 [1] TRUE
 

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -26,14 +26,6 @@ describe('Using LRU cache', {
     expect_true(cache$exists('hello'))
   })
 
-  test_that('Test peek', {
-    cache <- LRUcache(2)
-    cache$set('hello', 'world')$set('cache', 'money')
-    expect_is(cache$last_accessed('cache'), 'POSIXct')
-    # did not update the timestamp metadata
-    expect_true(cache$last_accessed('hello') < cache$last_accessed('cache'))
-  })
-
   test_that('Test with byte size', {
     cache <- LRUcache('150B')
     cache$set('foo', 54.124)

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -45,6 +45,15 @@ describe('Using LRU cache', {
     expect_true(cache$last_accessed('hello') < Sys.time())
   })
 
+  test_that('Test last_accessed after peek', {
+    cache <- LRUcache(1)
+    cache$set('hello', 'world')
+    time <- Sys.time()
+    cache$peek('hello')
+    expect_is(cache$last_accessed('hello'), 'POSIXct')
+    expect_true(cache$last_accessed('hello') < time)
+  })
+
   test_that('Test with byte size', {
     cache <- LRUcache('150B')
     cache$set('foo', 54.124)

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -26,6 +26,25 @@ describe('Using LRU cache', {
     expect_true(cache$exists('hello'))
   })
 
+  test_that('Test last_accessed after set', {
+    cache <- LRUcache(1)
+    time <- Sys.time()
+    cache$set('hello', 'world')
+    expect_is(cache$last_accessed('hello'), 'POSIXct')
+    expect_true(cache$last_accessed('hello') > time)
+    expect_true(cache$last_accessed('hello') < Sys.time())
+  })
+
+  test_that('Test last_accessed after get', {
+    cache <- LRUcache(1)
+    cache$set('hello', 'world')
+    time <- Sys.time()
+    cache$get('hello')
+    expect_is(cache$last_accessed('hello'), 'POSIXct')
+    expect_true(cache$last_accessed('hello') > time)
+    expect_true(cache$last_accessed('hello') < Sys.time())
+  })
+
   test_that('Test with byte size', {
     cache <- LRUcache('150B')
     cache$set('foo', 54.124)


### PR DESCRIPTION
Hi all, this adds the peek method to the public API.
Public peek function returns `value`, like `get` but without timestamp modification.
Added set/get/peek tests for `last_accessed`.