### PR TITLE
list_all method

### DIFF
--- a/R/lru.R
+++ b/R/lru.R
@@ -35,6 +35,9 @@ LRUcache_ <- R6::R6Class("LRUcache_",
       stopifnot(name %in% ls(private$data))
       private$data[[name]]$timestamp
     },
+    list_all = function() {
+      ls(private$data)
+    },
     print = function() {
       cat(sprintf("<LRUcache> of capacity %0.f%s", private$max_num, private$units),
           toString(private$format_cache())

--- a/tests/testthat/test-LRU.R
+++ b/tests/testthat/test-LRU.R
@@ -95,4 +95,12 @@ describe('Using LRU cache', {
     expect_false(cache$exists("foo"))
   })
 
+  test_that("It can produce a list of all cached values", {
+    cache <- LRUcache(10)
+    cache$set("foo", 1)
+    cache$set("bar", 2)
+    expect_true(setequal(cache$list_all(), c("foo", "bar")))
+    cache$set("baz", 3)
+  })
+
 })


### PR DESCRIPTION
adding a method to give a list of keys for all objects in a cache.